### PR TITLE
移除本地服务器连接限制

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,8 +9,8 @@
     "storage"
   ],
   "host_permissions": [
-    "http://localhost:*/",
-    "http://127.0.0.1:*/"
+    "http://*/",
+    "https://*/"
   ],
   "action": {
     "default_popup": "popup.html"

--- a/popup.js
+++ b/popup.js
@@ -74,19 +74,7 @@ async function onServerUrlChange() {
       console.error('Failed to save server config:', error);  
     }  
     updateStatus('offline', '未连接');
-    startSelectionButton.disabled = true;
-    
-    // 检查是否需要显示权限提示
-    if (!isLocalUrl(url)) {  
-      const smallEl = permissionInfo.querySelector('small');  
-      if (smallEl) {  
-        smallEl.textContent = '⚠️ 当前版本仅支持本地服务器连接';  
-        smallEl.style.color = '#e74c3c';  
-      }  
-      permissionInfo.style.display = 'block';  
-    } else {  
-      permissionInfo.style.display = 'none';  
-    }  
+    startSelectionButton.disabled = true;  
   }
 }
 
@@ -96,18 +84,6 @@ function isValidUrl(string) {
     const url = new URL(string);
     return url.protocol === 'http:' || url.protocol === 'https:';
   } catch (_) {
-    return false;
-  }
-}
-
-// 检查URL是否为本地地址
-function isLocalUrl(url) {
-  try {
-    const urlObj = new URL(url);
-    return urlObj.hostname === 'localhost' || 
-           urlObj.hostname === '127.0.0.1' || 
-           urlObj.hostname === '0.0.0.0';
-  } catch (error) {
     return false;
   }
 }
@@ -123,12 +99,6 @@ async function testServerConnection() {
 
   if (!isValidUrl(url)) {
     updateStatus('offline', '无效的URL格式');
-    return;
-  }
-
-  // 检查是否为外部URL
-  if (!isLocalUrl(url)) {
-    updateStatus('offline', '当前版本只支持本地服务器 (localhost/127.0.0.1)');
     return;
   }
 


### PR DESCRIPTION
- 删除 onServerUrlChange 函数中的本地URL检查逻辑
- 移除 testServerConnection 函数中的本地服务器限制
- 删除不再使用的 isLocalUrl 函数
- 更新 manifest.json 中的 host_permissions，允许访问任何 HTTP/HTTPS 地址
- 现在支持连接到任何远程服务器